### PR TITLE
Update thirdparty.yaml

### DIFF
--- a/site/data/thirdparty.yaml
+++ b/site/data/thirdparty.yaml
@@ -179,7 +179,7 @@ integrations:
     notes: OWASP Tool
  
   - name: 'Dradis'
-    link: https://dradisframework.com/ce/
+    link: https://dradis.com/ce/
     license: 'Open source community edition'
  
   - name: 'Faraday'


### PR DESCRIPTION
Hi,

I’ve seen that you're linking to Dradis on your page.

We migrated our website to dradis.com in 2023, but Google doesn’t seem to have figured out that dradis.com is our new domain, and we’re losing a lot of traffic as a result.

We’re trying to update links to our previous domains, so they link directly to the new domain. I'd really appreciate it if you'd be able to update this link for me.

Thank you